### PR TITLE
generate missing response objects (e.g. details)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ snappi/*
 !snappi/snappigenerator.py
 !snappi/tests
 # !snappi/tests/test_serialize.py
+scratch

--- a/snappi/tests/test_e2e_port_flow_config.py
+++ b/snappi/tests/test_e2e_port_flow_config.py
@@ -54,15 +54,17 @@ def test_e2e_port_flow_config(api):
     api.set_transmit_state(transmit_state)
 
     # get port metrics
-    port_metrics_request = api.port_metrics_request()
-    port_metrics = api.get_port_metrics(port_metrics_request)
-    for metric in port_metrics:
+    req = api.metrics_request()
+    req.choice = req.PORT
+    res = api.get_metrics(req)
+    for metric in res.port_metrics:
         print(metric)
 
     # get flow metrics
-    flow_metrics_request = api.flow_metrics_request()
-    flow_metrics = api.get_flow_metrics(flow_metrics_request)
-    for metric in flow_metrics:
+    req = api.metrics_request()
+    req.choice = req.FLOW
+    res = api.get_metrics(req)
+    for metric in res.flow_metrics:
         print(metric)
 
 

--- a/snappi/tests/test_port_metrics.py
+++ b/snappi/tests/test_port_metrics.py
@@ -5,11 +5,11 @@ def test_port_metrics(api, b2b_config):
     """Get port metrics
     """
     api.set_config(b2b_config)
-    port_metrics_request = api.port_metrics_request()
-    port_metrics = api.get_port_metrics(port_metrics_request)
-    for metric in port_metrics:
+    req = api.metrics_request()
+    req.choice = req.PORT
+    res = api.get_metrics(req)
+    for metric in res.port_metrics:
         print(metric)
-
 
 if __name__ == '__main__':
     pytest.main(['-vv', '-s', __file__])


### PR DESCRIPTION
@ajbalogh kindly review following in a sequence to get a better context of the changes that went in. There were other things I wanted to fix but for now added a TODO to be addessed later (needs more discussion).

1. No classes were generated for some responses. I made a change to generate class for responses with 200 status code. https://github.com/open-traffic-generator/snappi/issues/31
2. After fixing above issues, I encountered another issue where I had to make more changes to the approved model changes like so: https://github.com/open-traffic-generator/models/commit/6c495fb39a44062ccc535fd1601b1240ff1c29a1
    - The issue was that PortMetric or FlowMetric classes were not generated. This should've been fixed in generator, but I took a shortcut by adjusting models (this can be reverted without affecting users)
3. Encountered another issue after fixing first one. https://github.com/open-traffic-generator/snappi/issues/41
   - Fix for this directly merged: https://github.com/open-traffic-generator/snappi/compare/v0.1.30...v0.1.32