### PR TITLE
change snappi list classes naming convention

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run sanity unit tests
       run: |
-        sudo python -m pytest -v
+        sudo pytest -v
 
     # to create a release it just needs a tag
     # the tag name MUST be in the following format:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run sanity unit tests
       run: |
-        pytest -v
+        sudo python pytest -v
 
     # to create a release it just needs a tag
     # the tag name MUST be in the following format:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Python
+
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
@@ -37,20 +38,24 @@ jobs:
       run: |
         python -m pip install --upgrade dist/snappi-${{ steps.get_version.outputs.version }}-py2.py3-none-any.whl[test]
 
-    # - name: Run unit tests
-    #   run: |
-    #     python -m pytest -sv snappi/tests
+    - name: Run sanity unit tests
+      run: |
+        python -m pytest -sv snappi/tests
 
-    - name: Get all changes
-      id: file_changes
-      uses: trilom/file-changes-action@v1.2.4
+    # to create a release it just needs a tag
+    # the tag name MUST be in the following format:
+    #   v<major>.<minor>.<build>
+    # git tag -a <tag name> -m "message"
+    # git push origin --tags
+    - name: Get git tag
+      run: echo "HEAD_TAG=$(git tag --points-at HEAD)" >> $GITHUB_ENV
 
-    - name: Output changed files
-      id: changed_files
-      run: echo ${{steps.file_changes.outputs.files_modified}}
+    - name: Read VERSION file
+      id: get_version
+      run: echo "::set-output name=version::$(cat VERSION)"
 
     - name: Create Release
-      if: true == contains(steps.file_changes.outputs.files_modified, 'VERSION')
+      if: env.HEAD_TAG != ''
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
@@ -61,7 +66,7 @@ jobs:
         prerelease: false
 
     - name: Upload Python Package To Release
-      if: true == contains(steps.file_changes.outputs.files_modified, 'VERSION')
+      if: env.HEAD_TAG != ''
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -71,7 +76,7 @@ jobs:
         file_glob: true   
 
     - name: Upload Models Release File To Release
-      if: true == contains(steps.file_changes.outputs.files_modified, 'VERSION')
+      if: env.HEAD_TAG != ''
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -81,7 +86,7 @@ jobs:
         file_glob: true 
 
     - name: Upload Assets to Pypi
-      if: true == contains(steps.file_changes.outputs.files_modified, 'VERSION')
+      if: env.HEAD_TAG != ''
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run sanity unit tests
       run: |
-        python -m pytest -sv snappi/tests
+        python -m pytest -v
 
     # to create a release it just needs a tag
     # the tag name MUST be in the following format:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run sanity unit tests
       run: |
-        python -m pytest -v
+        pytest -v
 
     # to create a release it just needs a tag
     # the tag name MUST be in the following format:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run sanity unit tests
       run: |
-        sudo python pytest -v
+        sudo python -m pytest -v
 
     # to create a release it just needs a tag
     # the tag name MUST be in the following format:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -50,10 +50,6 @@ jobs:
     - name: Get git tag
       run: echo "HEAD_TAG=$(git tag --points-at HEAD)" >> $GITHUB_ENV
 
-    - name: Read VERSION file
-      id: get_version
-      run: echo "::set-output name=version::$(cat VERSION)"
-
     - name: Create Release
       if: env.HEAD_TAG != ''
       uses: actions/create-release@v1

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Run sanity unit tests
       run: |
-        sudo pytest -v
+        sudo ${{ env.pythonLocation }}/python -m pytest -v
 
     # to create a release it just needs a tag
     # the tag name MUST be in the following format:

--- a/snappi/snappicommon.py
+++ b/snappi/snappicommon.py
@@ -154,7 +154,7 @@ class SnappiObject(SnappiBase):
         """
         output = {}
         for key, value in self._properties.items():
-            if isinstance(value, (SnappiObject, SnappiList)):
+            if isinstance(value, (SnappiObject, SnappiIter)):
                 output[key] = value._encode()
             else:
                 output[key] = value
@@ -188,7 +188,7 @@ class SnappiObject(SnappiBase):
         object_class = getattr(module, class_name)
         if is_property_list is True:
             list_class = object_class
-            object_class = getattr(module, class_name[0:-3])
+            object_class = getattr(module, class_name[0:-4])
         return (list_class, object_class)
 
     def __str__(self):
@@ -210,7 +210,7 @@ class SnappiObject(SnappiBase):
         return self.__deepcopy__(None)
 
 
-class SnappiList(SnappiBase):
+class SnappiIter(SnappiBase):
     """Container class for SnappiObject
 
     Inheriting classes contain 0..n instances of an OpenAPI components/schemas 
@@ -229,7 +229,7 @@ class SnappiList(SnappiBase):
     __slots__ = ('_index', '_items')
 
     def __init__(self):
-        super(SnappiList, self).__init__()
+        super(SnappiIter, self).__init__()
         self._index = -1
         self._items = []
 
@@ -272,7 +272,7 @@ class SnappiList(SnappiBase):
         self._index = len(self._items) - 1
 
     def append(self, item):
-        """Append an item to the end of the SnappiList
+        """Append an item to the end of the SnappiIter
         TBD: type check, raise error on mismatch
         """
         self._add(item)
@@ -285,7 +285,7 @@ class SnappiList(SnappiBase):
         return [item._encode() for item in self._items]
 
     def _decode(self, encoded_snappi_list):
-        item_class_name = self.__class__.__name__.replace('Seq', '')
+        item_class_name = self.__class__.__name__.replace('Iter', '')
         module = importlib.import_module(self.__module__)
         object_class = getattr(module, item_class_name)
         self.clear()
@@ -293,10 +293,10 @@ class SnappiList(SnappiBase):
             self._add(object_class()._decode(item))
 
     def __copy__(self):
-        raise NotImplementedError('Shallow copy of SnappiList objects is not supported')
+        raise NotImplementedError('Shallow copy of SnappiIter objects is not supported')
 
     def __deepcopy__(self, memo):
-        raise NotImplementedError('Deep copy of SnappiList objects is not supported')
+        raise NotImplementedError('Deep copy of SnappiIter objects is not supported')
 
     def __str__(self):
         return yaml.safe_dump(self._encode())

--- a/snappi/snappigenerator.py
+++ b/snappi/snappigenerator.py
@@ -121,7 +121,7 @@ class SnappiGenerator(object):
             self._write(1, 'pass')
 
             self._write(0, 'from .snappicommon import SnappiObject')
-            self._write(0, 'from .snappicommon import SnappiList')
+            self._write(0, 'from .snappicommon import SnappiIter')
             self._write(0, 'from .snappicommon import SnappiHttpTransport')
 
         methods, factories = self._get_methods_and_factories()
@@ -226,7 +226,7 @@ class SnappiGenerator(object):
             if schema_object['type'] == 'array':
                 ref = schema_object['items']['$ref']
                 _, _, class_name, _ = self._get_object_property_class_names(ref)
-                class_name = '%sSeq' % class_name
+                class_name = '%sIter' % class_name
                 self._top_level_schema_refs.append((ref, property_name))
             self._top_level_schema_refs.append((ref, None))
 
@@ -526,7 +526,7 @@ class SnappiGenerator(object):
         yobject = self._get_object_from_ref(ref)
         ref_name = ref.split('/')[-1]
         contained_class_name = ref_name.replace('.', '')
-        class_name = '%sSeq' % contained_class_name
+        class_name = '%sIter' % contained_class_name
         if class_name in self._generated_classes:
             return
         self._generated_classes.append(class_name)
@@ -536,7 +536,7 @@ class SnappiGenerator(object):
         with open(self._api_filename, 'a') as self._fid:
             self._write()
             self._write()
-            self._write(0, 'class %s(SnappiList):' % class_name)
+            self._write(0, 'class %s(SnappiIter):' % class_name)
             self._write(1, "__slots__ = ()")
             self._write()
             self._write(1, 'def __init__(self):')
@@ -584,7 +584,7 @@ class SnappiGenerator(object):
         self._write(2, 'return self._getitem(key)')
         self._write()
         self._write(1, 'def __iter__(self):')
-        self._write(2, '# type: () -> %sSeq' % contained_class_name)
+        self._write(2, '# type: () -> %sIter' % contained_class_name)
         self._write(2, 'return self._iter()')
         self._write()
         self._write(1, 'def __next__(self):')
@@ -609,7 +609,7 @@ class SnappiGenerator(object):
             self._imports.append('from .%s import %s' % (class_name.lower(), class_name))
             self._write(1, 'def %s(self%s):' % (method_name, param_string))
             if contained_class_name is not None:
-                self._write(2, "# type: () -> %sSeq" % (contained_class_name))
+                self._write(2, "# type: () -> %sIter" % (contained_class_name))
             else:
                 self._write(2, "# type: () -> %s" % (class_name))
             self._write(2, '"""Factory method that creates an instance of %s class' % (class_name))
@@ -664,7 +664,7 @@ class SnappiGenerator(object):
             object_name = ref[0].value.split('/')[-1]
             class_name = object_name.replace('.', '')
             if restriction.startswith('list['):
-                type_name = '%sSeq' % class_name
+                type_name = '%sIter' % class_name
             else:
                 type_name = class_name
         else:
@@ -696,7 +696,7 @@ class SnappiGenerator(object):
                 self._write(2, "self._set_property('%s', value)" % (name))
         elif len(ref) > 0:
             if restriction.startswith('list['):
-                self._write(2, "return self._get_property('%s', %sSeq)" % (name, class_name))
+                self._write(2, "return self._get_property('%s', %sIter)" % (name, class_name))
             else:
                 self._write(2, "return self._get_property('%s', %s)" % (name, class_name))
 
@@ -724,7 +724,7 @@ class SnappiGenerator(object):
                     object_name = ref[0].value.split('/')[-1]
                     class_name = object_name.replace('.', '')
                     if 'type' in yproperty and yproperty['type'] == 'array':
-                        class_name += 'Seq'
+                        class_name += 'Iter'
                     types.append((name, class_name))
         return types
 

--- a/snappi/tests/snappiserver.py
+++ b/snappi/tests/snappiserver.py
@@ -78,7 +78,7 @@ class SnappiServer(object):
         self._web_server_thread = threading.Thread(target=web_server)
         self._web_server_thread.setDaemon(True)
         self._web_server_thread.start()
-        self._wait_until_ready()
+        # self._wait_until_ready()
         return self
 
     def _wait_until_ready(self):
@@ -88,5 +88,5 @@ class SnappiServer(object):
                 api.get_config()
                 break
             except Exception as err:
-                pass
+                print(err)
             time.sleep(0.1)

--- a/snappi/tests/snappiserver.py
+++ b/snappi/tests/snappiserver.py
@@ -78,7 +78,7 @@ class SnappiServer(object):
         self._web_server_thread = threading.Thread(target=web_server)
         self._web_server_thread.setDaemon(True)
         self._web_server_thread.start()
-        # self._wait_until_ready()
+        self._wait_until_ready()
         return self
 
     def _wait_until_ready(self):
@@ -87,6 +87,6 @@ class SnappiServer(object):
             try:
                 api.get_config()
                 break
-            except Exception as err:
-                print(err)
-            time.sleep(0.1)
+            except Exception:
+                pass
+            time.sleep(.1)

--- a/snappi/tests/test_bgp_sr_te_policy.py
+++ b/snappi/tests/test_bgp_sr_te_policy.py
@@ -87,4 +87,4 @@ def test_bgp_sr_te_policy(api):
 
 
 if __name__ == '__main__':
-    pytest.main(['-s', __file__])
+    pytest.main(['-sv', __file__])

--- a/snappi/tests/test_device_stack.py
+++ b/snappi/tests/test_device_stack.py
@@ -21,7 +21,7 @@ def test_device_stack(api):
     i6.address = '2001::1'
     b6 = i6.bgpv6
     b6.name = 'b6'
-
+    api.set_config(config)
     print(config)
 
 

--- a/snappi/tests/test_snappi_lists.py
+++ b/snappi/tests/test_snappi_lists.py
@@ -8,7 +8,7 @@ def test_snappi_lists(api):
     config = api.config()
 
     flows = config.flows.flow(name='1')
-    assert(flows.__class__ == snappi.FlowSeq)
+    assert(flows.__class__ == snappi.FlowIter)
     flow = flows[0]
     assert(flow.__class__ == snappi.Flow)
     eth, vlan, vlan1 = flow.packet.ethernet().vlan().vlan()
@@ -25,7 +25,7 @@ def test_snappi_lists(api):
 
     flow = config.flows.flow(name='3')[-1]
     pkt = flow.packet.ethernet().vlan()
-    assert(pkt.__class__ == snappi.FlowHeaderSeq)
+    assert(pkt.__class__ == snappi.FlowHeaderIter)
     vlan = pkt[-1]
     vlan.id.value = 3
 


### PR DESCRIPTION
To avoid naming conflicts, infrastructure and generated snappi container classes should end with the suffix Iter instead of Seq or List. 