### PR TITLE
Add prefer binary flag to pip install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+--prefer-binary
 flake8
 requests
 openapiart==0.1.22


### PR DESCRIPTION
### Issue
Python 2.7  is taking too long in github action

### Fix
add --prefer-binary flag to pip install 

### Validation
manually inspect workflow for 2.7 to ensure binaries are not being built if not required